### PR TITLE
Fix removing leading slash for root action, mutation and getter 

### DIFF
--- a/samples/store/store.ts
+++ b/samples/store/store.ts
@@ -1,4 +1,4 @@
-import { Module, State } from '../../src';
+import { Action, Getter, Module, Mutation, State } from '../../src';
 import { MyModule } from './modules/MyModule';
 import { TestModule } from './modules/TestModule';
 
@@ -11,4 +11,23 @@ export class MyStore {
 
   @State()
   public version = '2.0.0';
+
+  @State()
+  public rootCounter = 0;
+
+  @Getter()
+  public get aRootCounter() {
+    return this.rootCounter;
+  }
+
+  @Mutation()
+  public incrementRootCounter() {
+    this.rootCounter += 1;
+  }
+
+  @Action()
+  public async actionIncrementRootCounter() {
+    await new Promise(r => setTimeout(r, 1000));
+    this.incrementRootCounter();
+  }
 }

--- a/samples/views/Home.vue
+++ b/samples/views/Home.vue
@@ -19,6 +19,10 @@
       <p>My2 Counter: {{ testModule.my2.counter }}</p>
       <button @click="testModule.my2.increment">Increment</button>
     </div>
+    <div>
+      <p>Root Counter: state/{{ store.rootCounter }}, getter/{{ store.aRootCounter }}</p>
+      <button @click="store.actionIncrementRootCounter">Increment - wait a sec</button>
+    </div>
   </div>
 </template>
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -145,7 +145,8 @@ function bindGetter(pBuilder: StoreBuilder, pModule: any, propertyName: string) 
   const options = pBuilder.options;
   const provider = pBuilder.provider;
   options.getters![propertyName] = getGetter(pModule, propertyName);
-  const getterName = pBuilder.namespaces.join('/') + '/' + propertyName;
+  const nsPath = pBuilder.namespaces.join('/');
+  const getterName = (nsPath ? nsPath + '/' : '') + propertyName;
 
   Object.defineProperty(pModule, propertyName, {
     get() {
@@ -164,7 +165,8 @@ function bindMutation(pBuilder: StoreBuilder, pModule: any, propertyName: string
   const options = pBuilder.options;
   const provider = pBuilder.provider;
   options.mutations![propertyName] = getMutation(pModule, propertyName);
-  const mutationName = pBuilder.namespaces.join('/') + '/' + propertyName;
+  const nsPath = pBuilder.namespaces.join('/');
+  const mutationName = (nsPath ? nsPath + '/' : '') + propertyName;
 
   pModule[propertyName] = (payload: any) => {
     provider.store!.commit(mutationName, payload);
@@ -181,7 +183,8 @@ function bindAction(pBuilder: StoreBuilder, pModule: any, propertyName: string) 
   const options = pBuilder.options;
   const provider = pBuilder.provider;
   options.actions![propertyName] = getAction(pModule, propertyName);
-  const actionName = pBuilder.namespaces.join('/') + '/' + propertyName;
+  const nsPath = pBuilder.namespaces.join('/');
+  const actionName = (nsPath ? nsPath + '/' : '') + propertyName;
 
   pModule[propertyName] = (payload: any) => {
     provider.store!.dispatch(actionName, payload);

--- a/tests/unit/simple.spec.ts
+++ b/tests/unit/simple.spec.ts
@@ -101,4 +101,14 @@ describe('Simple tests', () => {
     expect($store.state.test.counter).toBe(2);
     expect(testModule.counter).toBe(2);
   });
+
+  it('root store counter', async () => {
+    const $store = createVuexStore(new MyStore());
+    const store = useStore<MyStore>($store);
+
+    expect(store.aRootCounter).toBe(0);
+    await store.incrementRootCounter();
+    await store.incrementRootCounter();
+    expect(store.aRootCounter).toBe(2);
+  });
 });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Root store's action/mutation/getter does not working because leading slash in name. 


* **What is the current behavior?** (You can also link to an open issue here)

```typescript
// src/store.ts
const getterName = pBuilder.namespaces.join('/') + '/' + propertyName;
const mutationName = pBuilder.namespaces.join('/') + '/' + propertyName;
const actionName = pBuilder.namespaces.join('/') + '/' + propertyName;
```

- **What is the new behavior (if this is a feature change)?**

```typescript
// src/store.ts
const nsPath = pBuilder.namespaces.join('/');
const getterName = (nsPath ? nsPath + '/' : '') + propertyName;
// same changes for mutationName, actionName
```
