### PR TITLE
Passing options object for register dynamic modules

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import { ModuleTree, Plugin, Store, StoreOptions } from 'vuex';
+import { ModuleOptions, ModuleTree, Plugin, Store, StoreOptions } from 'vuex';
 
 import { removeStaticError } from './errors';
 import { transformRecursive } from './transform';
@@ -45,7 +45,8 @@ export function createVuexStore<T extends object>(
 export function registerModule<T extends object>(
   store: Store<any>,
   namespace: string[],
-  instance: T
+  instance: T,
+  options?: ModuleOptions
 ) {
   const typedStore = store as TypedStore<any>;
   if (!typedStore.__vxs_modules__) {
@@ -55,7 +56,7 @@ export function registerModule<T extends object>(
     modules: typedStore.__vxs_modules__
   };
   const vuexModule = transformRecursive(storeProvider, instance, namespace, true);
-  store.registerModule(namespace, vuexModule);
+  store.registerModule(namespace, vuexModule, options);
   storeProvider.store = store;
 }
 

--- a/tests/unit/dynamic.spec.ts
+++ b/tests/unit/dynamic.spec.ts
@@ -50,6 +50,33 @@ describe('Dynamic modules', () => {
     expect(my!.counter).toBe(8);
   });
 
+  it('register dynamic module preserving state', () => {
+    const $store = createVuexStore(new MyStore());
+    $store.replaceState({
+      ...$store.state,
+      toto: {
+        counter: 1
+      }
+    });
+    const my = new MyModule(3);
+    registerModule($store, ['toto'], my, {
+      preserveState: true
+    });
+
+    expect(my).not.toBe(undefined);
+    expect(my!.counter).toBe(1);
+
+    let thrownError;
+    try {
+      my!.increment();
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBe(undefined);
+    expect(my!.counter).toBe(2);
+  });
+
   it('useModule', () => {
     const $store = createVuexStore(new MyStore());
     registerModule($store, ['toto'], new MyModule(6));


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Added parameter from options in 'registerModule' function and passing this object to native vuex function

* **What is the current behavior?** (You can also link to an open issue here)

Options object does not supported in 'registerModule' function

- **What is the new behavior (if this is a feature change)?**

Options object supported and correct works
